### PR TITLE
feat(frontend): novo layout de gestão de equipes e membros

### DIFF
--- a/frontend/src/app/equipe/equipe.component.css
+++ b/frontend/src/app/equipe/equipe.component.css
@@ -61,12 +61,6 @@
   margin: 0.35rem 0 0;
 }
 
-.rule-note {
-  margin: 0.35rem 0 0;
-  font-size: 0.85rem;
-  color: #6b7280;
-}
-
 .role-pill {
   background: #f2f3f5;
   padding: 0.5rem 1rem;
@@ -74,41 +68,81 @@
   font-size: 0.9rem;
 }
 
+/* Layout Grid */
+.layout-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .card {
   background: #fff;
   border-radius: 14px;
-  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05);
   padding: 1.5rem;
   margin-bottom: 1.25rem;
+  border: 1px solid #f1f5f9;
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid #f1f5f9;
+  padding-bottom: 0.75rem;
 }
 
-.count,
-.hint {
+.card-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #1e293b;
+}
+
+.count, .hint {
   font-size: 0.85rem;
-  color: #6b7280;
+  color: #64748b;
 }
 
+/* Teams List */
 .table {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .table-row {
   display: grid;
-  grid-template-columns: 2fr 2.5fr 1.2fr 0.8fr;
+  grid-template-columns: 1fr auto;
   gap: 1rem;
   align-items: center;
   padding: 0.75rem 1rem;
   border-radius: 10px;
   background: #f8fafc;
+  transition: all 0.2s;
+  border: 1px solid transparent;
+}
+
+.team-item {
+  cursor: pointer;
+}
+
+.team-item:hover {
+  background: #f1f5f9;
+  border-color: #e2e8f0;
+}
+
+.active-team {
+  background: #eef2ff !important;
+  border-color: #c7d2fe !important;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
 }
 
 .table-head {
@@ -117,6 +151,7 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 0.75rem;
+  cursor: default;
 }
 
 .cell-name {
@@ -126,129 +161,165 @@
 }
 
 .avatar {
-  width: 34px;
-  height: 34px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
-  background: #2f3b55;
+  background: var(--color-primary);
   color: #fff;
   display: grid;
   place-items: center;
   font-weight: 600;
+  flex-shrink: 0;
 }
 
-.cell-email {
-  font-size: 0.95rem;
-  color: #1f2937;
+.team-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
 }
 
-.role-select {
-  padding: 0.35rem 0.5rem;
-  border-radius: 8px;
-  border: 1px solid #e5e7eb;
+.team-name {
+  font-weight: 600;
+  color: #1e293b;
 }
 
-.role-chip {
-  display: inline-flex;
-  padding: 0.25rem 0.6rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  background: #e5e7eb;
+.role-chip-small {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  width: fit-content;
+  font-weight: 700;
+  text-transform: uppercase;
 }
 
-.role-admin {
-  background: #fee2e2;
-  color: #991b1b;
-}
-
-.role-editor {
-  background: #dbeafe;
-  color: #1e3a8a;
-}
-
-.role-viewer {
-  background: #dcfce7;
-  color: #166534;
-}
+.role-admin { background: #fee2e2; color: #991b1b; }
+.role-editor { background: #dbeafe; color: #1e3a8a; }
+.role-viewer { background: #dcfce7; color: #166534; }
 
 .actions-col {
   display: flex;
-  justify-content: flex-end;
+  gap: 0.25rem;
 }
 
+/* Member Column */
+.empty-selection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.empty-selection p {
+  margin-top: 1rem;
+}
+
+.add-member-box {
+  background: #f8fafc;
+  padding: 1.25rem;
+  border-radius: 10px;
+  margin-bottom: 1.5rem;
+  border: 1px dashed #cbd5e1;
+}
+
+.add-member-box h4 {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.form-compact {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.form-compact input, .form-compact select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  font-size: 0.875rem;
+  flex: 1;
+  min-width: 150px;
+}
+
+.members-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.member-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background: #fff;
+  border: 1px solid #f1f5f9;
+  border-radius: 10px;
+  transition: border-color 0.2s;
+}
+
+.member-row:hover {
+  border-color: #e2e8f0;
+}
+
+.member-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.member-name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #1e293b;
+}
+
+.member-email {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.member-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.role-select-compact {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+/* Buttons */
 .btn {
   border: none;
   border-radius: 8px;
-  padding: 0.5rem 0.9rem;
+  padding: 0.6rem 1.2rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  transition: all 0.2s;
+  font-size: 0.9rem;
 }
 
-.btn-primary {
-  background: #004a80;
-  color: #fff;
+.btn-sm {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
 }
 
-.btn-primary:hover {
-  background: #003359;
-}
+.btn-primary { background: var(--color-primary); color: #fff; }
+.btn-primary:hover { background: var(--color-primary-hover); }
 
-.btn-danger {
-  background: #fff5f5;
-  color: #b71c1c;
-  border: 1px solid rgba(183, 28, 28, 0.25);
-}
+.btn-secondary { background: #f1f5f9; color: #475569; }
+.btn-secondary:hover { background: #e2e8f0; }
 
-.btn-danger:hover {
-  background: #f8d7da;
-}
-
-.btn-secondary {
-  background-color: #f8f9fa;
-  color: #4a5568;
-  border: 1px solid #dcdfe6;
-}
-
-.btn-secondary:hover {
-  background-color: #edf2f7;
-}
-
-.form {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-  align-items: end;
-}
-
-label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-weight: 600;
-  color: #111827;
-}
-
-input,
-select {
-  padding: 0.5rem 0.6rem;
-  border-radius: 8px;
-  border: 1px solid #e5e7eb;
-}
-
-@media (max-width: 780px) {
-  .hero {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .table-row {
-    grid-template-columns: 1fr;
-  }
-
-  .actions-col {
-    justify-content: flex-start;
-  }
-}
+.btn-danger { background: #fee2e2; color: #991b1b; }
+.btn-danger:hover { background: #fecaca; }
 
 .btn-icon {
   background: transparent;
@@ -260,61 +331,122 @@ select {
   transition: all 0.2s;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
 }
 
 .btn-icon:hover {
+  background: #f1f5f9;
+  color: var(--color-primary);
+}
+
+.btn-danger-icon:hover {
   background: #fee2e2;
   color: #ef4444;
 }
 
+/* Feedback Banner */
+.feedback-banner {
+  padding: 1rem 1.5rem;
+  border-radius: 10px;
+  margin-bottom: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+  animation: slideDown 0.3s ease-out;
+}
+
+.sucesso { background: #dcfce7; color: #166534; border-left: 5px solid #22c55e; }
+.erro { background: #fee2e2; color: #991b1b; border-left: 5px solid #ef4444; }
+
+.btn-close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: currentColor;
+  opacity: 0.5;
+  line-height: 1;
+}
+
+.btn-close:hover { opacity: 1; }
+
+/* Modal */
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(15, 23, 42, 0.6);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 9999;
-  padding: 24px;
+  backdrop-filter: blur(4px);
 }
 
 .modal-content {
   background: white;
   padding: 2rem;
-  border-radius: 12px;
+  border-radius: 16px;
   max-width: 450px;
-  width: 100%;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 90%;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
   animation: modalFade 0.2s ease-out;
-}
-
-.modal-content h3 {
-  margin-top: 0;
-  color: #1e293b;
 }
 
 .modal-footer {
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
-  margin-top: 1.5rem;
+  margin-top: 2rem;
 }
 
 .warning {
   color: #ef4444;
-  font-size: 0.875rem;
+  font-weight: 600;
   margin-top: 0.5rem;
-  font-weight: 500;
+}
+
+/* Team Form Section */
+.team-form-section {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #f1f5f9;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #334155;
+}
+
+.form-actions-compact {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+@keyframes slideDown {
+  from { transform: translateY(-20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
 }
 
 @keyframes modalFade {
-  from {
-    opacity: 0;
-    transform: translateY(20px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.carregando-spinner {
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-primary);
+  font-weight: 600;
 }

--- a/frontend/src/app/equipe/equipe.component.html
+++ b/frontend/src/app/equipe/equipe.component.html
@@ -7,106 +7,158 @@
 </header>
 
 <main class="page">
+  <!-- Feedback Global -->
+  <div *ngIf="mensagemFeedback" class="feedback-banner" [ngClass]="tipoFeedback">
+    {{ mensagemFeedback }}
+    <button class="btn-close" (click)="limparFeedback()">×</button>
+  </div>
+
   <section class="hero">
     <div class="hero-text">
       <h1>Gerenciar Equipes</h1>
       <p class="subtitle">
-        Crie, edite e visualize os times cadastrados no sistema.
+        Crie, edite e gerencie os membros dos times cadastrados.
       </p>
     </div>
     <div class="role-pill">
-      Role atual: <strong>{{ currentUserRole }}</strong>
+      Perfil Global: <strong>{{ currentUserRole }}</strong>
     </div>
   </section>
 
-  <section class="card">
-    <div class="card-header">
-      <h2>Minhas Equipes</h2>
-      <span class="count">{{ equipes.length }} total</span>
-    </div>
-
-    <div class="table">
-      <div class="table-row table-head">
-        <div>Nome da Equipe</div>
-        <div>Descrição</div>
-        <div>ID</div>
-        <div style="text-align: right;">Ações</div>
+  <div class="layout-grid">
+    <!-- Coluna de Equipes -->
+    <section class="card teams-column">
+      <div class="card-header">
+        <h2>Minhas Equipes</h2>
+        <span class="count">{{ equipes.length }} total</span>
       </div>
 
-      <div class="table-row" *ngFor="let eq of equipes">
-        <div class="cell-name">
-          <span class="avatar">{{ eq.nome.slice(0, 1) | uppercase }}</span>
-          <span>{{ eq.nome }}</span>
+      <div class="table">
+        <div class="table-row table-head">
+          <div>Equipe</div>
+          <div style="text-align: right;">Ações</div>
         </div>
-        <div class="cell-email">{{ eq.descricao || 'Sem descrição' }}</div>
-        <div>
-           <span class="role-chip" [ngClass]="{
-             'role-admin': eq.role === 'ADMIN',
-             'role-editor': eq.role === 'EDITOR',
-             'role-viewer': eq.role === 'VIEWER'
-           }">{{ eq.role }}</span>
+
+        <div class="table-row team-item" 
+             *ngFor="let eq of equipes" 
+             [ngClass]="{'active-team': equipeAtiva?.id === eq.id}"
+             (click)="selecionarEquipe(eq)">
+          <div class="cell-name">
+            <span class="avatar">{{ eq.nome.slice(0, 1) | uppercase }}</span>
+            <div class="team-info">
+              <span class="team-name">{{ eq.nome }}</span>
+              <span class="role-chip-small" [ngClass]="'role-' + eq.role?.toLowerCase()">{{ eq.role }}</span>
+            </div>
+          </div>
+          <div class="actions-col" (click)="$event.stopPropagation()">
+            <button class="btn-icon" title="Editar" (click)="prepararEdicao(eq)" *ngIf="podeEditar(eq)">
+              <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7M18.5 2.5a2.121 2.121 0 113 3L12 15l-4 1 1-4 9.5-9.5z" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+            <button class="btn-icon btn-danger-icon" title="Remover" (click)="removerEquipe(eq)" *ngIf="podeRemover(eq)">
+              <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2M10 11v6M14 11v6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+          </div>
         </div>
-        <div style="text-align: right; display: flex; justify-content: flex-end; gap: 0.5rem;">
 
-          <button class="btn-icon" title="Editar" (click)="prepararEdicao(eq)" *ngIf="podeEditar(eq)">
-            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7M18.5 2.5a2.121 2.121 0 113 3L12 15l-4 1 1-4 9.5-9.5z" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
-
-          <button class="btn-icon btn-danger-icon" title="Remover" (click)="removerEquipe(eq)" *ngIf="podeRemover(eq)">
-            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2M10 11v6M14 11v6" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </button>
+        <div *ngIf="equipes.length === 0" class="empty-state">
+          Nenhuma equipe encontrada.
         </div>
       </div>
 
-      <div *ngIf="equipes.length === 0" style="padding: 1rem; text-align: center; color: #6b7280;">
-        Nenhuma equipe encontrada. Crie uma abaixo!
+      <!-- Formulário de Equipe -->
+      <div class="team-form-section">
+        <h3 class="section-title">{{ isEditando ? 'Editar Equipe' : 'Criar Equipe' }}</h3>
+        <form class="form-compact" (ngSubmit)="salvar()">
+          <input type="text" [(ngModel)]="novaEquipe.nome" name="nome" placeholder="Nome da equipe" required />
+          <input type="text" [(ngModel)]="novaEquipe.descricao" name="descricao" placeholder="Descrição (opcional)" />
+          <div class="form-actions-compact">
+            <button class="btn btn-primary btn-sm" type="submit">{{ isEditando ? 'Salvar' : 'Criar' }}</button>
+            <button *ngIf="isEditando" class="btn btn-secondary btn-sm" type="button" (click)="cancelarEdicao()">Cancelar</button>
+          </div>
+        </form>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="card">
-    <div class="card-header">
-      <h2>{{ isEditando ? 'Editar Equipe' : 'Criar Nova Equipe' }}</h2>
-      <span class="hint">
-        {{ isEditando ? 'Alterando dados da equipe #' + idEquipeSendoEditada : 'Salva direto no Banco de Dados (Supabase)' }}
-      </span>
-    </div>
-
-    <form class="form" (ngSubmit)="salvar()">
-      <label>
-        Nome da Equipe
-        <input type="text" [(ngModel)]="novaEquipe.nome" name="nome" placeholder="Ex: Time de Desenvolvimento" required />
-      </label>
-      <label>
-        Descrição
-        <input type="text" [(ngModel)]="novaEquipe.descricao" name="descricao" placeholder="Propósito da equipe" />
-      </label>
-
-      <div style="display: flex; gap: 1rem; margin-top: 1rem;">
-        <button class="btn btn-primary" type="submit">
-          {{ isEditando ? 'Salvar Alterações' : 'Criar Equipe' }}
-        </button>
-
-        <button *ngIf="isEditando" class="btn btn-secondary" type="button" (click)="cancelarEdicao()">
-          Cancelar
-        </button>
+    <!-- Coluna de Membros -->
+    <section class="card members-column">
+      <div class="card-header">
+        <h2>Membros da Equipe</h2>
+        <span class="hint" *ngIf="equipeAtiva">{{ equipeAtiva.nome }}</span>
       </div>
-    </form>
-  </section>
 
+      <div *ngIf="!equipeAtiva" class="empty-selection">
+        <svg width="48" height="48" fill="none" stroke="#cbd5e1" stroke-width="1.5" viewBox="0 0 24 24">
+          <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2m8-10a4 4 0 100-8 4 4 0 000 8zm14 0h-6m3-3v6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <p>Selecione uma equipe para gerenciar os membros</p>
+      </div>
+
+      <div *ngIf="equipeAtiva">
+        <!-- Adicionar Membro (Somente ADMIN da equipe) -->
+        <div class="add-member-box" *ngIf="podeGerenciarMembros(equipeAtiva)">
+          <h4>Adicionar Membro</h4>
+          <form class="form-compact" (ngSubmit)="adicionarMembro()">
+            <input type="email" [(ngModel)]="novoMembroEmail" name="email" placeholder="E-mail do usuário" required />
+            <select [(ngModel)]="novoMembroRole" name="role">
+              <option value="VIEWER">VIEWER</option>
+              <option value="EDITOR">EDITOR</option>
+              <option value="ADMIN">ADMIN</option>
+            </select>
+            <button class="btn btn-primary btn-sm" type="submit">Adicionar</button>
+          </form>
+        </div>
+
+        <div class="carregando-spinner" *ngIf="carregandoMembros">Carregando...</div>
+
+        <div class="members-list" *ngIf="!carregandoMembros">
+          <div class="member-row" *ngFor="let m of membros">
+            <div class="member-info">
+              <span class="member-name">{{ m.nomeExibicao }}</span>
+              <span class="member-email">{{ m.email }}</span>
+            </div>
+            
+            <div class="member-actions">
+              <select class="role-select-compact" 
+                      [ngModel]="m.role" 
+                      (ngModelChange)="alterarPapel(m, $event)"
+                      *ngIf="podeGerenciarMembros(equipeAtiva)">
+                <option value="VIEWER">VIEWER</option>
+                <option value="EDITOR">EDITOR</option>
+                <option value="ADMIN">ADMIN</option>
+              </select>
+              <span class="role-chip-small" *ngIf="!podeGerenciarMembros(equipeAtiva)" [ngClass]="'role-' + m.role.toLowerCase()">
+                {{ m.role }}
+              </span>
+
+              <button class="btn-icon btn-danger-icon" 
+                      (click)="removerMembro(m)" 
+                      *ngIf="podeGerenciarMembros(equipeAtiva)">
+                <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div *ngIf="membros.length === 0" class="empty-state">Esta equipe ainda não possui membros.</div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <!-- Modal de Confirmação de Equipe -->
   <div class="modal-overlay" *ngIf="isConfirmOpen" (click)="onConfirmOverlayClick($event)">
     <div class="modal-content">
-      <h3>Confirmar Remoção</h3>
+      <h3>Excluir Equipe</h3>
       <p>Deseja realmente excluir a equipe <strong>{{ equipeToRemove?.nome }}</strong>?</p>
-      <p class="warning">Esta ação não pode ser desfeita e removerá todos os vínculos desta equipe na PROPLAN.</p>
+      <p class="warning">Esta ação é irreversível e removerá todos os acessos vinculados.</p>
 
       <div class="modal-footer">
         <button class="btn btn-secondary" (click)="fecharConfirmacao()">Cancelar</button>
-        <button class="btn btn-danger" (click)="confirmarRemocao()">Excluir</button>
+        <button class="btn btn-danger" (click)="confirmarRemocao()">Confirmar Exclusão</button>
       </div>
     </div>
   </div>

--- a/frontend/src/app/equipe/equipe.component.ts
+++ b/frontend/src/app/equipe/equipe.component.ts
@@ -2,8 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { EquipeService, Equipe } from '../services/equipe.services';
-import { Observable } from 'rxjs';
+import { EquipeService, Equipe, MembroEquipe } from '../services/equipe.services';
 
 export type UserRole = 'VIEWER' | 'EDITOR' | 'ADMIN';
 
@@ -29,6 +28,16 @@ export class EquipeComponent implements OnInit {
   isEditando = false;
   idEquipeSendoEditada: number | null = null;
 
+  // Gestão de Membros
+  membros: MembroEquipe[] = [];
+  equipeAtiva: Equipe | null = null;
+  novoMembroEmail = '';
+  novoMembroRole: UserRole = 'VIEWER';
+  
+  mensagemFeedback = '';
+  tipoFeedback: 'sucesso' | 'erro' = 'sucesso';
+  carregandoMembros = false;
+
   constructor(private equipeService: EquipeService) {}
 
   ngOnInit(): void {
@@ -44,11 +53,93 @@ export class EquipeComponent implements OnInit {
     return equipe.role === 'ADMIN';
   }
 
+  podeGerenciarMembros(equipe: Equipe | null): boolean {
+    return equipe?.role === 'ADMIN';
+  }
+
   carregarEquipes(): void {
     this.equipeService.listarMinhasEquipes().subscribe({
       next: (dados) => this.equipes = dados,
       error: (erro) => console.error('Erro ao buscar equipes', erro)
     });
+  }
+
+  selecionarEquipe(equipe: Equipe): void {
+    this.equipeAtiva = equipe;
+    this.carregarMembros(equipe.id!);
+    this.limparFeedback();
+  }
+
+  carregarMembros(equipeId: number): void {
+    this.carregandoMembros = true;
+    this.equipeService.listarMembros(equipeId).subscribe({
+      next: (dados) => {
+        this.membros = dados;
+        this.carregandoMembros = false;
+      },
+      error: (erro) => {
+        this.exibirFeedback('Erro ao carregar membros.', 'erro');
+        this.carregandoMembros = false;
+      }
+    });
+  }
+
+  adicionarMembro(): void {
+    if (!this.equipeAtiva || !this.novoMembroEmail) return;
+
+    this.equipeService.adicionarMembro(this.equipeAtiva.id!, this.novoMembroEmail, this.novoMembroRole).subscribe({
+      next: () => {
+        this.exibirFeedback('Membro adicionado com sucesso!', 'sucesso');
+        this.carregarMembros(this.equipeAtiva!.id!);
+        this.novoMembroEmail = '';
+      },
+      error: (erro) => {
+        const msg = erro.error?.mensagem || 'Erro ao adicionar membro. Verifique o e-mail e as permissões.';
+        this.exibirFeedback(msg, 'erro');
+      }
+    });
+  }
+
+  removerMembro(membro: MembroEquipe): void {
+    if (!this.equipeAtiva) return;
+    if (!confirm(`Deseja remover ${membro.nomeExibicao} da equipe?`)) return;
+
+    this.equipeService.removerMembro(this.equipeAtiva.id!, membro.usuarioId).subscribe({
+      next: () => {
+        this.exibirFeedback('Membro removido com sucesso!', 'sucesso');
+        this.carregarMembros(this.equipeAtiva!.id!);
+      },
+      error: (erro) => {
+        const msg = erro.error?.mensagem || 'Erro ao remover membro.';
+        this.exibirFeedback(msg, 'erro');
+      }
+    });
+  }
+
+  alterarPapel(membro: MembroEquipe, novoRole: string): void {
+    if (!this.equipeAtiva) return;
+
+    this.equipeService.alterarPapel(this.equipeAtiva.id!, membro.usuarioId, novoRole).subscribe({
+      next: () => {
+        this.exibirFeedback('Papel alterado com sucesso!', 'sucesso');
+        this.carregarMembros(this.equipeAtiva!.id!);
+      },
+      error: (erro) => {
+        const msg = erro.error?.mensagem || 'Erro ao alterar papel.';
+        this.exibirFeedback(msg, 'erro');
+        // Reverte localmente para o valor anterior se necessário (opcional)
+      }
+    });
+  }
+
+  exibirFeedback(msg: string, tipo: 'sucesso' | 'erro'): void {
+    this.mensagemFeedback = msg;
+    this.tipoFeedback = tipo;
+    setTimeout(() => this.limparFeedback(), 5000);
+  }
+
+  limparFeedback(): void {
+    this.mensagemFeedback = '';
   }
 
   criarEquipe(): void {
@@ -59,8 +150,11 @@ export class EquipeComponent implements OnInit {
       next: (equipeCriada) => {
         this.equipes.push(equipeCriada);
         this.novaEquipe = { nome: '', descricao: '' }; // Limpa o form
+        this.exibirFeedback('Equipe criada com sucesso!', 'sucesso');
       },
-      error: (erro) => console.error('Erro ao criar equipe', erro)
+      error: (erro) => {
+        this.exibirFeedback('Erro ao criar equipe.', 'erro');
+      }
     });
   }
   salvar(): void {
@@ -69,7 +163,9 @@ export class EquipeComponent implements OnInit {
         next: () => {
           this.carregarEquipes(); // Recarrega a lista
           this.cancelarEdicao();
-        }
+          this.exibirFeedback('Equipe atualizada!', 'sucesso');
+        },
+        error: () => this.exibirFeedback('Erro ao atualizar equipe.', 'erro')
       });
     } else {
       this.criarEquipe(); // Sua função original de POST
@@ -103,12 +199,16 @@ export class EquipeComponent implements OnInit {
     this.equipeService.remover(id).subscribe({
       next: () =>{
         this.equipes = this.equipes.filter(e => e.id !== id);
-        console.log(`Equipe ${id} removida com sucesso.`);
+        if (this.equipeAtiva?.id === id) {
+          this.equipeAtiva = null;
+          this.membros = [];
+        }
+        this.exibirFeedback('Equipe removida com sucesso.', 'sucesso');
         this.fecharConfirmacao();
       },
       error: (erro) =>{
-        console.error(`Erro ao remover equipe no servidor`, erro);
-        alert(`Não foi possível remover a equipe, verifique sua conexão ou permissão`);
+        const msg = erro.error?.mensagem || 'Erro ao remover equipe. Verifique suas permissões.';
+        this.exibirFeedback(msg, 'erro');
         this.fecharConfirmacao();
       }
     });

--- a/frontend/src/app/services/equipe.services.ts
+++ b/frontend/src/app/services/equipe.services.ts
@@ -9,6 +9,13 @@ export interface Equipe{
   role?: 'ADMIN' | 'EDITOR' | 'VIEWER';
 }
 
+export interface MembroEquipe {
+  usuarioId: number;
+  nomeExibicao: string;
+  email: string;
+  role: 'ADMIN' | 'EDITOR' | 'VIEWER';
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -32,7 +39,19 @@ export class EquipeService{
     return this.http.put<Equipe>(`${this.apiURL}/${id}`, equipe);
   }
 
+  listarMembros(equipeId: number): Observable<MembroEquipe[]> {
+    return this.http.get<MembroEquipe[]>(`${this.apiURL}/${equipeId}/membros`);
+  }
 
+  adicionarMembro(equipeId: number, email: string, role: string): Observable<MembroEquipe> {
+    return this.http.post<MembroEquipe>(`${this.apiURL}/${equipeId}/membros`, { email, role });
+  }
 
+  removerMembro(equipeId: number, usuarioId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiURL}/${equipeId}/membros/${usuarioId}`);
+  }
 
+  alterarPapel(equipeId: number, usuarioId: number, role: string): Observable<MembroEquipe> {
+    return this.http.put<MembroEquipe>(`${this.apiURL}/${equipeId}/membros/${usuarioId}`, { role });
+  }
 }


### PR DESCRIPTION
- Reestruturação da tela de equipes para layout de duas colunas (equipe ativa/membros).
- Implementação de listagem, adição, remoção e troca de papel de membros.
- Bloqueio de UI para ações administrativas para não-admins da equipe.
- Novo sistema de feedback (banner) para sucesso e erros (403/404/validação).
- Estilização completa seguindo as cores oficiais e mantendo padrão visual.
- Métodos de serviço para gestão de membros vinculados ao backend.